### PR TITLE
Migrate to local dependencies for @material/web and Preact

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,7 +12,6 @@
 	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet">
 	<link rel="stylesheet" href="style.css">
-	<script type="module" src="https://unpkg.com/@material/web@1.5.0/all.js?module"></script>
 	<link rel="manifest" href="site.webmanifest">
 	<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230f172a'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='central' text-anchor='middle' font-family='Inter,Arial' font-size='28' fill='%23fff'%3EPD%3C/text%3E%3C/svg%3E">
 </head>

--- a/contact.html
+++ b/contact.html
@@ -12,7 +12,6 @@
 	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet">
 	<link rel="stylesheet" href="style.css">
-	<script type="module" src="https://unpkg.com/@material/web@1.5.0/all.js?module"></script>
 	<link rel="manifest" href="site.webmanifest">
 	<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230f172a'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='central' text-anchor='middle' font-family='Inter,Arial' font-size='28' fill='%23fff'%3EPD%3C/text%3E%3C/svg%3E">
 </head>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
 	<link href="https://fonts.googleapis.com/css2?family=Manrope:wght@500;700;800&display=swap" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet">
 	<link rel="stylesheet" href="style.css">
-	<script type="module" src="https://unpkg.com/@material/web@1.5.0/all.js?module"></script>
 	<link rel="manifest" href="site.webmanifest">
 	<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230f172a'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='central' text-anchor='middle' font-family='Inter,Arial' font-size='28' fill='%23fff'%3EPD%3C/text%3E%3C/svg%3E">
 	<script type="application/ld+json">{

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "thepinak503.github.io",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "@material/web": "^2.4.1",
+        "preact": "^10.28.3"
+      },
       "devDependencies": {
         "vite": "^7.1.3"
       }
@@ -454,6 +458,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@material/web": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@material/web/-/web-2.4.1.tgz",
+      "integrity": "sha512-0sk9t25acJ72Qv3r0n9r0lgDbPaAKnpm0p+QmEAAwYyZomHxuVbgrrAdtNXaRm7jFyGh+WsTr8bhtvCnpPRFjw==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "catalog"
+      ],
+      "dependencies": {
+        "lit": "^2.8.0 || ^3.0.0",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.48.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.48.1.tgz",
@@ -741,6 +773,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
@@ -816,6 +854,37 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -884,6 +953,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.28.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
+      "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.48.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.48.1.tgz",
@@ -950,6 +1029,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/vite": {
       "version": "7.1.3",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,9 @@
   "private": "true",
   "devDependencies": {
     "vite": "^7.1.3"
+  },
+  "dependencies": {
+    "@material/web": "^2.4.1",
+    "preact": "^10.28.3"
   }
 }

--- a/projects.html
+++ b/projects.html
@@ -12,7 +12,6 @@
 	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet">
 	<link rel="stylesheet" href="style.css">
-	<script type="module" src="https://unpkg.com/@material/web@1.5.0/all.js?module"></script>
 	<link rel="manifest" href="site.webmanifest">
 	<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230f172a'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='central' text-anchor='middle' font-family='Inter,Arial' font-size='28' fill='%23fff'%3EPD%3C/text%3E%3C/svg%3E">
 </head>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,5 @@
+import '@material/web/all.js';
+
 document.addEventListener('DOMContentLoaded', () => {
 	const root = document.documentElement;
 	const yearEl = document.getElementById('year');
@@ -145,10 +147,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		const loader = () => {
 			if (once.loaded) return;
 			once.loaded = true;
-			const scriptEl = document.createElement('script');
-			scriptEl.type = 'module';
-			scriptEl.src = './web-components/projects-app.js';
-			document.body.appendChild(scriptEl);
+			import('./web-components/projects-app.js');
 		};
 		const obs = new IntersectionObserver((entries) => {
 			entries.forEach(entry => {

--- a/web-components/projects-app.js
+++ b/web-components/projects-app.js
@@ -1,8 +1,5 @@
-// Minimal Preact-once loader delivered as native module for GitHub Pages
-// No build step required. Uses esm.sh CDN for Preact to keep repo simple.
-
-import { h, render } from 'https://esm.sh/preact@10.20.2?external=preact/hooks';
-import { useEffect, useMemo, useState } from 'https://esm.sh/preact@10.20.2/hooks';
+import { h, render } from 'preact';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 
 const DEFAULT_PROJECTS = [
     { id: 'p1', name: 'Project 1', desc: 'A brief description of the first project highlighting goals and outcomes.', tech: ['HTML','CSS','JavaScript'], live: '#', code: '#', likes: 0 },


### PR DESCRIPTION
This change updates the project to use local NPM packages for `@material/web` and `preact` instead of loading them from external CDNs. This ensures the site is self-contained and dependencies are correctly bundled by Vite.

Changes include:
- `package.json`: Added `@material/web` and `preact` dependencies.
- `script.js`: Imported `@material/web/all.js` and updated the lazy loader to use `import()`.
- `index.html`, `about.html`, `contact.html`, `projects.html`: Removed CDN script tags.
- `web-components/projects-app.js`: Switched to local `preact` imports.

---
*PR created automatically by Jules for task [13187473564810377064](https://jules.google.com/task/13187473564810377064) started by @thepinak503*